### PR TITLE
fix kilo rdo

### DIFF
--- a/labs/osbash/scripts/yum_init.sh
+++ b/labs/osbash/scripts/yum_init.sh
@@ -23,7 +23,7 @@ set_yum_proxy
 
 # Enable RDO repo
 if [[ ${OPENSTACK_RELEASE:-} = kilo ]]; then
-    sudo yum install -y "https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm"
+    sudo yum install -y "https://repos.fedorapeople.org/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm" 
 elif [[ ${OPENSTACK_RELEASE:-} = liberty ]]; then
     sudo yum install -y "https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-2.noarch.rpm"
 else


### PR DESCRIPTION
<img width="751" alt="screen shot 2016-05-26 at 9 18 19 pm" src="https://cloud.githubusercontent.com/assets/6479173/15574311/923330a4-2387-11e6-9606-9cb1d58d0100.png">

Original RDO path is not found now. Therefore I changed it to
https://repos.fedorapeople.org/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm
